### PR TITLE
Add support for different storage type #5

### DIFF
--- a/depot.js
+++ b/depot.js
@@ -31,10 +31,10 @@
 
       if (this.ids.indexOf(id) < 0) {
         this.ids.push(id);
-        localStorage.setItem(this.name, this.ids.join(","));
+        this.storageAdaptor.setItem(this.name, this.ids.join(","));
       }
 
-      localStorage.setItem(getKey(this.name, id), JSON.stringify(record));
+      this.storageAdaptor.setItem(getKey(this.name, id), JSON.stringify(record));
 
       return record;
     },
@@ -69,11 +69,12 @@
     find: function (criteria) {
       var key, match, record;
       var name = this.name;
+      var self = this;
 
       if (!criteria) return this.all();
 
       return this.ids.reduce(function (memo, id) {
-        record = jsonData(localStorage.getItem(getKey(name, id)));
+        record = jsonData(self.storageAdaptor.getItem(getKey(name, id)));
         match = findMatch(criteria, record);
 
         if (match) {
@@ -85,14 +86,14 @@
     },
 
     get: function (id) {
-      return jsonData(localStorage.getItem(getKey(this.name, id)));
+      return jsonData(this.storageAdaptor.getItem(getKey(this.name, id)));
     },
 
     all: function () {
-      var record, name = this.name;
+      var record, self = this, name = this.name;
 
       return this.ids.reduce(function (memo, id) {
-        record = localStorage.getItem(getKey(name, id));
+        record = self.storageAdaptor.getItem(getKey(name, id));
 
         if (record) {
           memo.push(jsonData(record));
@@ -107,12 +108,12 @@
       var id = (record[this.idAttribute]) ? record[this.idAttribute] : record;
       var key = getKey(this.name, id);
 
-      record = jsonData(localStorage.getItem(key));
-      localStorage.removeItem(key);
+      record = jsonData(this.storageAdaptor.getItem(key));
+      this.storageAdaptor.removeItem(key);
 
       index = this.ids.indexOf(id);
       if (index != -1) this.ids.splice(index, 1);
-      localStorage.setItem(this.name, this.ids.join(","));
+      this.storageAdaptor.setItem(this.name, this.ids.join(","));
 
       return record;
     },
@@ -126,25 +127,25 @@
 
         if (criteria) {
 
-          record = jsonData(localStorage.getItem(key));
+          record = jsonData(this.storageAdaptor.getItem(key));
           match = findMatch(criteria, record);
 
           if (match) {
-            localStorage.removeItem(key);
+            this.storageAdaptor.removeItem(key);
             this.ids.splice(i, 1);
           }
 
         }
         else {
-          localStorage.removeItem(key);
+          this.storageAdaptor.removeItem(key);
         }
       }
 
       if (criteria) {
-        localStorage.setItem(this.name, this.ids.join(","));
+        this.storageAdaptor.setItem(this.name, this.ids.join(","));
       }
       else {
-        localStorage.removeItem(this.name);
+        this.storageAdaptor.removeItem(this.name);
         this.ids = [];
       }
     },
@@ -203,17 +204,22 @@
   function depot(name, options) {
     var store, ids;
 
-    if (!localStorage) throw new Error("localStorage not found");
+    options = extend({
+      idAttribute: '_id',
+      storageAdaptor: localStorage
+    }, options);
 
-    store = localStorage.getItem(name);
+    if (!options.storageAdaptor) throw new Error("No storage adaptor was found");
+
+    store = options.storageAdaptor.getItem(name);
     ids = (store && store.split(",")) || [];
-    options = options || {};
 
     return Object.create(api, {
       name: { value: name },
       store: { value: store },
       ids: { value: ids, writable: true },
-      idAttribute: { value: options.idAttribute || '_id' }
+      idAttribute: { value: options.idAttribute },
+      storageAdaptor: {value: options.storageAdaptor }
     });
   }
 

--- a/specs/depot_spec.js
+++ b/specs/depot_spec.js
@@ -21,6 +21,35 @@ describe('depot', function () {
     var todos = store.all();
     expect(todos.length).to.equal(2);
   });
+  
+  it('should support sessionStorage', function() {
+    var store = depot('todos', { storageType: sessionStorage });
+    var todo = store.save({ title: 'todo3' }); 
+
+    var result = store.get(todo._id);
+    expect(result.title).to.equal('todo3');
+    expect(result).to.be.ok;
+  });
+
+  it('should support a simple object for storage', function() {
+    var storeObj = {
+      store: {},
+      setItem: function(key, value) {
+        this.store[key] = value;
+      },
+      getItem: function(key) {
+        return this.store[key];
+      },
+      removeItem: function(key) {
+        delete this.store[key];
+      }
+    };
+
+    var store = depot('todos', { storageType: storeObj });
+    var todo = store.save({ title: 'todo3' });
+    var result = store.get(todo._id);
+    expect(result.title).to.equal('todo3');
+  });
 
   describe("#save", function () {
     it("should save new records", function () {


### PR DESCRIPTION
Following up the referenced issue. I've allowed the user to pass an object into the options that will be used for storage. This can be a simple in-memory object if it follows the three API methods laid out by localStorage/sessionStorage. The simplest solution that doesn't impact the existing API or use of depot.

Declaring the object in the options possibly makes [the check for the presence of the object](https://github.com/simonsmith/depot.js/commit/d980315a825fac7d0d715f3ea7cd69fe41af5312#L0R212) redundant, so not sure whether to handle this a different way.

Also happy to add to the documentation once this has been reviewed.
