### PR TITLE
Fix for IE8's lack of support for Object.create

### DIFF
--- a/depot.js
+++ b/depot.js
@@ -234,11 +234,23 @@
 
     if (!options.storageAdaptor) throw new Error("No storage adaptor was found");
 
-    instance = Object.create(api, {
-      name: { value: name },
-      idAttribute: { value: options.idAttribute },
-      storageAdaptor: { value: options.storageAdaptor }
-    });
+    if (Object.create) {
+      instance = Object.create(api, {
+        name: { value: name },
+        idAttribute: { value: options.idAttribute },
+        storageAdaptor: { value: options.storageAdaptor }
+      });      
+    } else {
+      instance = (function () {
+        var f = function(){};
+        f.prototype = api;
+        var d = new f();
+        d.name = name;
+        d.idAttribute = options.idAttribute;
+        d.storageAdaptor = options.storageAdaptor;
+        return d;
+      }());
+    }
 
     instance.refresh();
 


### PR DESCRIPTION
depot.js uses various parts of the ES5 standard, like Array.indexOf and Object.create. But while polyfills exist that can handle the use of Array.indexOf, none (to my knowledge) exist that will handle Object.create with a second parameter. This branch aims to fix that so IE8 can be shimmed to work with depot.js.
